### PR TITLE
Fix deployment file

### DIFF
--- a/infrastructure/deploylib/app.py
+++ b/infrastructure/deploylib/app.py
@@ -56,7 +56,7 @@ SYMFONY_ELASTICSEARCH_HOST={host}
 SYMFONY_RABBITMQ_HOST={host}
 SYMFONY_RABBITMQ_NODENAME={host}
 SYMFONY_ASSETS_HOST={asset_host}""" \
-        .format(host=Config.local_ip, asset_host=Config.asset_host)
+        .format(host=Config.local_ip, asset_host=Config.assets_host)
     print('Generating your default environment variables...')
     run('echo "%s" > .env.local' % variables)
     print(color_white + 'Created ' + color_cyan + '.env.local' + color_white + ' file')


### PR DESCRIPTION
## Context 
When following the deployment tutorial, the command `fab local.app.setup-default-env-vars` failed with this error

```bash
Traceback (most recent call last):
  File "/home/dynnammo/.local/share/virtualenvs/cap-collectif-5u3rwTWK/bin/fab", line 8, in <module>
    sys.exit(program.run())
  File "/home/dynnammo/.local/share/virtualenvs/cap-collectif-5u3rwTWK/lib/python3.10/site-packages/invoke/program.py", line 384, in run
    self.execute()
  File "/home/dynnammo/.local/share/virtualenvs/cap-collectif-5u3rwTWK/lib/python3.10/site-packages/invoke/program.py", line 566, in execute
    executor.execute(*self.tasks)
  File "/home/dynnammo/.local/share/virtualenvs/cap-collectif-5u3rwTWK/lib/python3.10/site-packages/invoke/executor.py", line 129, in execute
    result = call.task(*args, **call.kwargs)
  File "/home/dynnammo/.local/share/virtualenvs/cap-collectif-5u3rwTWK/lib/python3.10/site-packages/invoke/tasks.py", line 127, in __call__
    result = self.body(*args, **kwargs)
  File "/tmp/cap-collectif/infrastructure/deploylib/local/app.py", line 44, in setup_default_env_vars
    app.setup_default_env_vars()
  File "/tmp/cap-collectif/infrastructure/deploylib/app.py", line 59, in setup_default_env_vars
    .format(host=Config.local_ip, asset_host=Config.asset_host)
AttributeError: type object 'Config' has no attribute 'asset_host'. Did you mean: 'assets_host'?
```

This PR fixes simply the faulty line.